### PR TITLE
Support for Lua 5.3 bitwise operators in lexer and parser

### DIFF
--- a/luaparse.js
+++ b/luaparse.js
@@ -592,15 +592,17 @@
 
       case 62: // >
         if (61 === next) return scanPunctuator('>=');
+        if (62 === next) return scanPunctuator('>>');
         return scanPunctuator('>');
 
       case 60: // <
+        if (60 === next) return scanPunctuator('<<');
         if (61 === next) return scanPunctuator('<=');
         return scanPunctuator('<');
 
       case 126: // ~
         if (61 === next) return scanPunctuator('~=');
-        return raise({}, errors.expected, '=', '~');
+        return scanPunctuator('~');
 
       case 58: // :
         if (58 === next) return scanPunctuator('::');
@@ -610,10 +612,15 @@
         // Check for a multiline string, they begin with [= or [[
         if (91 === next || 61 === next) return scanLongStringLiteral();
         return scanPunctuator('[');
+  
+      case 47: // /
+        // Check for integer division op (//)
+        if (47 === next) return scanPunctuator('//')
+        return scanPunctuator('/')  
 
-      // \* / ^ % , { } ] ( ) ; # - +
-      case 42: case 47: case 94: case 37: case 44: case 123: case 125:
-      case 93: case 40: case 41: case 59: case 35: case 45: case 43:
+      // * ^ % , { } ] ( ) ; & # - + |
+      case 42: case 94: case 37: case 44: case 123: case 124: case 125:
+      case 93: case 40: case 41: case 59: case 38: case 35: case 45: case 43:
         return scanPunctuator(input.charAt(index));
     }
 
@@ -1094,7 +1101,7 @@
   }
 
   function isUnary(token) {
-    if (Punctuator === token.type) return '#-'.indexOf(token.value) >= 0;
+    if (Punctuator === token.type) return '#-~'.indexOf(token.value) >= 0;
     if (Keyword === token.type) return 'not' === token.value;
     return false;
   }
@@ -1798,15 +1805,22 @@
 
     if (1 === length) {
       switch (charCode) {
-        case 94: return 10; // ^
-        case 42: case 47: case 37: return 7; // * / %
-        case 43: case 45: return 6; // + -
+        case 94: return 12; // ^
+        case 42: case 47: case 37: return 10; // * / %
+        case 43: case 45: return 9; // + -
+        case 38: return 6; // &
+        case 126: return 5; // ~
+        case 124: return 4; // |
         case 60: case 62: return 3; // < >
       }
     } else if (2 === length) {
       switch (charCode) {
-        case 46: return 5; // ..
-        case 60: case 62: case 61: case 126: return 3; // <= >= == ~=
+        case 47: return 10; // //
+        case 46: return 8; // ..
+        case 60: case 62:
+            if('<<' === operator || '>>' === operator) return 7; // << >>
+            return 3; // <= >=
+        case 61: case 126: return 3; // == ~=
         case 111: return 1; // or
       }
     } else if (97 === charCode && 'and' === operator) return 2;


### PR DESCRIPTION
Adds support for the following operators:

Binary
`>>, <<, //, &, |, ~`

Unary
`~`

Operator precedence was taken from Roberto's post on the Lua-users mailing list:
http://lua-users.org/lists/lua-l/2014-03/msg00632.html