### PR TITLE
Add onScopeIdentifierName callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The available options are:
   created.
 - `onDestroyScope: null` A callback which will be invoked when the current
   scope is destroyed.
+- `onScopeIdentifierName: null` A callback which will be invoked when a new identifier is added to the current scope. The identifier's name will be passed as the only parameter.
 - `luaVersion: '5.1'` The version of Lua the parser will target; supported
   values are `'5.1'`, `'5.2'` and `'5.3'`.
 

--- a/luaparse.js
+++ b/luaparse.js
@@ -1267,7 +1267,7 @@
   function scopeIdentifierName(name) {
     if (-1 !== indexOf(scopes[scopeDepth], name)) return;
     scopes[scopeDepth].push(name);
-    if (options.onScopeIdentifierName) options.onScopeIdentifierName();
+    if (options.onScopeIdentifierName) options.onScopeIdentifierName(name);
   }
 
   // Add identifier to the current scope

--- a/luaparse.js
+++ b/luaparse.js
@@ -1265,9 +1265,9 @@
 
   // Add identifier name to the current scope if it doesnt already exist.
   function scopeIdentifierName(name) {
+    if (options.onScopeIdentifierName) options.onScopeIdentifierName(name);
     if (-1 !== indexOf(scopes[scopeDepth], name)) return;
     scopes[scopeDepth].push(name);
-    if (options.onScopeIdentifierName) options.onScopeIdentifierName(name);
   }
 
   // Add identifier to the current scope

--- a/luaparse.js
+++ b/luaparse.js
@@ -74,6 +74,9 @@
     , onCreateScope: null
     // A callback which will be invoked when the current scope is destroyed.
     , onDestroyScope: null
+    // A callback which will be invoked when a new identifier is added to the current scope.
+    // The identifier's name will be passed as the only parameter
+    , onScopeIdentifierName: null
     // The version of Lua targeted by the parser (string; allowed values are '5.1', '5.2', '5.3'.)
     , luaVersion: '5.1'
   };
@@ -1264,6 +1267,7 @@
   function scopeIdentifierName(name) {
     if (-1 !== indexOf(scopes[scopeDepth], name)) return;
     scopes[scopeDepth].push(name);
+    if (options.onScopeIdentifierName) options.onScopeIdentifierName();
   }
 
   // Add identifier to the current scope


### PR DESCRIPTION
Hi. I'm working on [a Lua autocomplete package for Atom](https://github.com/dapetcu21/atom-autocomplete-lua) and I figured I would use luaparse.

In my use case, I need to know which identifier is local to which scope ahead of time, since the parsing might error out at the user's cursor as he's editing. That's why I added this callback, which used together with `onCreateScope` and `onDestroyScope` gives me a complete idea about the locality of identifiers without having to wait for the node to fully close (for example, a `for i = 1, 10` statement would only tell me about `i` when the block is closed).
