### PR TITLE
Remove empty statements in Lua 5.1

### DIFF
--- a/luaparse.js
+++ b/luaparse.js
@@ -183,9 +183,9 @@
       };
     }
 
-    , repemaybeCallStatement: function(condition, body) {
+    , callStatement: function(condition, body) {
       return {
-          type: 'RepemaybeCallStatement'
+          type: 'CallStatement'
         , condition: condition
         , body: body
       };
@@ -1400,7 +1400,7 @@
           return parseFunctionDeclaration(name);
         case 'while':    next(); return parseWhileStatement();
         case 'for':      next(); return parseForStatement();
-        case 'repeat':   next(); return parseRepemaybeCallStatement();
+        case 'repeat':   next(); return parseCallStatement();
         case 'break':    next(); return parseBreakStatement();
         case 'do':       next(); return parseDoStatement();
         case 'goto':     next(); return parseGotoStatement();
@@ -1482,14 +1482,14 @@
 
   //     repeat ::= 'repeat' block 'until' exp
 
-  function parseRepemaybeCallStatement() {
+  function parseCallStatement() {
     if (options.scope) createScope();
     var body = parseBlock();
     expect('until');
     var condition = parseExpectedExpression();
     if (options.scope) destroyScope();
     consume(';');
-    return finishNode(ast.repemaybeCallStatement(condition, body));
+    return finishNode(ast.callStatement(condition, body));
   }
 
   //     retstat ::= 'return' [exp {',' exp}] [';']

--- a/luaparse.js
+++ b/luaparse.js
@@ -183,9 +183,9 @@
       };
     }
 
-    , callStatement: function(condition, body) {
+    , repeatStatement: function(condition, body) {
       return {
-          type: 'CallStatement'
+          type: 'RepeatStatement'
         , condition: condition
         , body: body
       };
@@ -1482,14 +1482,14 @@
 
   //     repeat ::= 'repeat' block 'until' exp
 
-  function parseCallStatement() {
+  function parseRepeatStatement() {
     if (options.scope) createScope();
     var body = parseBlock();
     expect('until');
     var condition = parseExpectedExpression();
     if (options.scope) destroyScope();
     consume(';');
-    return finishNode(ast.callStatement(condition, body));
+    return finishNode(ast.repeatStatement(condition, body));
   }
 
   //     retstat ::= 'return' [exp {',' exp}] [';']

--- a/luaparse.js
+++ b/luaparse.js
@@ -1400,7 +1400,7 @@
           return parseFunctionDeclaration(name);
         case 'while':    next(); return parseWhileStatement();
         case 'for':      next(); return parseForStatement();
-        case 'repeat':   next(); return parseCallStatement();
+        case 'repeat':   next(); return parseRepeatStatement();
         case 'break':    next(); return parseBreakStatement();
         case 'do':       next(); return parseDoStatement();
         case 'goto':     next(); return parseGotoStatement();

--- a/test/scaffolding/statements
+++ b/test/scaffolding/statements
@@ -5,3 +5,8 @@ nil                                     -- FAIL
 ::foo::
 goto                                    -- FAIL
 goto foo
+// { "luaVersion": "5.1" }
+call1();(0)()
+;;                                      -- FAIL
+// { "luaVersion": "5.2" }
+;;

--- a/test/spec/statements.js
+++ b/test/spec/statements.js
@@ -202,6 +202,201 @@
         "ranges": true,
         "luaVersion": "5.2"
       }
-    }
+    },
+    "call1();(0)()": {
+      "result": {
+        "type": "Chunk",
+        "body": [
+          {
+            "type": "CallStatement",
+            "expression": {
+              "type": "CallExpression",
+              "base": {
+                "type": "Identifier",
+                "name": "call1",
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 0
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 5
+                  }
+                },
+                "range": [
+                  0,
+                  5
+                ],
+                "isLocal": false
+              },
+              "arguments": [],
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 7
+                }
+              },
+              "range": [
+                0,
+                7
+              ]
+            },
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "line": 1,
+                "column": 8
+              }
+            },
+            "range": [
+              0,
+              8
+            ]
+          },
+          {
+            "type": "CallStatement",
+            "expression": {
+              "type": "CallExpression",
+              "base": {
+                "type": "NumericLiteral",
+                "value": 0,
+                "raw": "0",
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 9
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 10
+                  }
+                },
+                "range": [
+                  9,
+                  10
+                ],
+                "inParens": true
+              },
+              "arguments": [],
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1,
+                  "column": 13
+                }
+              },
+              "range": [
+                8,
+                13
+              ]
+            },
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 8
+              },
+              "end": {
+                "line": 1,
+                "column": 13
+              }
+            },
+            "range": [
+              8,
+              13
+            ]
+          }
+        ],
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 13
+          }
+        },
+        "range": [
+          0,
+          13
+        ],
+        "comments": [],
+        "globals": [
+          {
+            "type": "Identifier",
+            "name": "call1",
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "line": 1,
+                "column": 5
+              }
+            },
+            "range": [
+              0,
+              5
+            ],
+            "isLocal": false
+          }
+        ]
+      },
+      "options": {
+        "scope": true,
+        "locations": true,
+        "ranges": true,
+        "luaVersion": "5.1"
+      }
+    },
+    ";;": {
+      "result": "[1:0] unexpected symbol ';' near ';'",
+      "options": {
+        "scope": true,
+        "locations": true,
+        "ranges": true,
+        "luaVersion": "5.1"
+      }
+    },
+    ";;": {
+      "result": {
+        "type": "Chunk",
+        "body": [],
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 2
+          }
+        },
+        "range": [
+          0,
+          2
+        ],
+        "comments": [],
+        "globals": []
+      },
+      "options": {
+        "scope": true,
+        "locations": true,
+        "ranges": true,
+        "luaVersion": "5.2"
+      }
+    },
   };
 }));

--- a/test/spec/statements.js
+++ b/test/spec/statements.js
@@ -397,6 +397,6 @@
         "ranges": true,
         "luaVersion": "5.2"
       }
-    },
+    }
   };
 }));


### PR DESCRIPTION
In Lua 5.1 empty statements can only appear at the end of a statement.
Check this: https://www.lua.org/manual/5.1/manual.html#2.4.1

I had to add an extra parameter to the parsePrefixExpression () to allow
call statement delimiting, i.e.: call();(0)(), it's valid in Lua 5.1.
Here's a Lua 5.1 online compiler: https://repl.it/languages/lua .