### PR TITLE
Add errors for invalid goto/label structure

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -41,7 +41,7 @@ gulp.task('lint', function() {
       , '.{bowerrc,jshintrc}'
     ]))
     .pipe(filelog())
-    .pipe(jshint())
+    .pipe(jshint({ esversion: 6 }))
     .pipe(jshint.reporter('default'))
     .pipe(jshint.reporter('fail'));
 });

--- a/test/scaffolding/statements
+++ b/test/scaffolding/statements
@@ -1,19 +1,27 @@
 break
-nil                                     -- FAIL
+nil                                                                         -- FAIL
 return;
-;                                       -- FAIL
+;                                                                           -- FAIL
 goto "foo"
-goto foo                                -- FAIL
+goto foo                                                                    -- FAIL
 // { "luaVersion": "5.2" }
 return;
-return;;                                -- FAIL
+return;;                                                                    -- FAIL
 ;
-::foo                                   -- FAIL
+::foo                                                                       -- FAIL
 ::foo::
-goto "foo"                              -- FAIL
-goto foo
+goto "foo"                                                                  -- FAIL
+goto foo ::foo::
+goto l1 do ::l1:: end                                                       -- FAIL
+do ::l1:: end goto l1                                                       -- FAIL
+::l1:: ::l1::                                                               -- FAIL
+goto l1; local aa ::l1:: ::l2:: print(3)                                    -- FAIL
+do local bb, cc; goto l1; end; local aa; ::l1:: print(3)                    -- FAIL
+repeat if x then goto cont end; local xuxu = 10; ::cont:: until xuxu < x    -- FAIL
+do goto l1 local a = 23 ::l1:: end
+do goto l1 goto l2 local x ::l1:: ::l2:: ::l3:: end
 // { "luaVersion": "LuaJIT" }
 ::foo::
 goto "foo"
-goto foo
-goto goto                               -- FAIL
+goto foo ::foo::
+goto goto                                                                   -- FAIL

--- a/test/spec/statements.js
+++ b/test/spec/statements.js
@@ -408,7 +408,7 @@
       }
     },
     {
-      "source": "goto foo",
+      "source": "goto foo ::foo::",
       "result": {
         "type": "Chunk",
         "body": [
@@ -446,6 +446,42 @@
               0,
               8
             ]
+          },
+          {
+            "type": "LabelStatement",
+            "label": {
+              "type": "Identifier",
+              "name": "foo",
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 11
+                },
+                "end": {
+                  "line": 1,
+                  "column": 14
+                }
+              },
+              "range": [
+                11,
+                14
+              ],
+              "isLocal": true
+            },
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 9
+              },
+              "end": {
+                "line": 1,
+                "column": 16
+              }
+            },
+            "range": [
+              9,
+              16
+            ]
           }
         ],
         "loc": {
@@ -455,12 +491,525 @@
           },
           "end": {
             "line": 1,
-            "column": 8
+            "column": 16
           }
         },
         "range": [
           0,
-          8
+          16
+        ],
+        "comments": [],
+        "globals": []
+      },
+      "options": {
+        "comments": true,
+        "locations": true,
+        "ranges": true,
+        "scope": true,
+        "luaVersion": "5.2"
+      }
+    },
+    {
+      "source": "goto l1 do ::l1:: end",
+      "result": "[1:8] no visible label 'l1' for <goto>",
+      "options": {
+        "comments": true,
+        "locations": true,
+        "ranges": true,
+        "scope": true,
+        "luaVersion": "5.2"
+      }
+    },
+    {
+      "source": "do ::l1:: end goto l1",
+      "result": "[1:21] no visible label 'l1' for <goto>",
+      "options": {
+        "comments": true,
+        "locations": true,
+        "ranges": true,
+        "scope": true,
+        "luaVersion": "5.2"
+      }
+    },
+    {
+      "source": "::l1:: ::l1::",
+      "result": "[1:11] label 'l1' already defined",
+      "options": {
+        "comments": true,
+        "locations": true,
+        "ranges": true,
+        "scope": true,
+        "luaVersion": "5.2"
+      }
+    },
+    {
+      "source": "goto l1; local aa ::l1:: ::l2:: print(3)",
+      "result": "[1:7] <goto l1> jumps into the scope of local 'aa'",
+      "options": {
+        "comments": true,
+        "locations": true,
+        "ranges": true,
+        "scope": true,
+        "luaVersion": "5.2"
+      }
+    },
+    {
+      "source": "do local bb, cc; goto l1; end; local aa; ::l1:: print(3)",
+      "result": "[1:24] <goto l1> jumps into the scope of local 'aa'",
+      "options": {
+        "comments": true,
+        "locations": true,
+        "ranges": true,
+        "scope": true,
+        "luaVersion": "5.2"
+      }
+    },
+    {
+      "source": "repeat if x then goto cont end; local xuxu = 10; ::cont:: until xuxu < x",
+      "result": "[1:27] <goto cont> jumps into the scope of local 'xuxu'",
+      "options": {
+        "comments": true,
+        "locations": true,
+        "ranges": true,
+        "scope": true,
+        "luaVersion": "5.2"
+      }
+    },
+    {
+      "source": "do goto l1 local a = 23 ::l1:: end",
+      "result": {
+        "type": "Chunk",
+        "body": [
+          {
+            "type": "DoStatement",
+            "body": [
+              {
+                "type": "GotoStatement",
+                "label": {
+                  "type": "Identifier",
+                  "name": "l1",
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 8
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 10
+                    }
+                  },
+                  "range": [
+                    8,
+                    10
+                  ]
+                },
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 3
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 10
+                  }
+                },
+                "range": [
+                  3,
+                  10
+                ]
+              },
+              {
+                "type": "LocalStatement",
+                "variables": [
+                  {
+                    "type": "Identifier",
+                    "name": "a",
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 17
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 18
+                      }
+                    },
+                    "range": [
+                      17,
+                      18
+                    ],
+                    "isLocal": true
+                  }
+                ],
+                "init": [
+                  {
+                    "type": "NumericLiteral",
+                    "value": 23,
+                    "raw": "23",
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 21
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 23
+                      }
+                    },
+                    "range": [
+                      21,
+                      23
+                    ]
+                  }
+                ],
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 23
+                  }
+                },
+                "range": [
+                  11,
+                  23
+                ]
+              },
+              {
+                "type": "LabelStatement",
+                "label": {
+                  "type": "Identifier",
+                  "name": "l1",
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 26
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 28
+                    }
+                  },
+                  "range": [
+                    26,
+                    28
+                  ],
+                  "isLocal": true
+                },
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 24
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 30
+                  }
+                },
+                "range": [
+                  24,
+                  30
+                ]
+              }
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "line": 1,
+                "column": 34
+              }
+            },
+            "range": [
+              0,
+              34
+            ]
+          }
+        ],
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 34
+          }
+        },
+        "range": [
+          0,
+          34
+        ],
+        "comments": [],
+        "globals": []
+      },
+      "options": {
+        "comments": true,
+        "locations": true,
+        "ranges": true,
+        "scope": true,
+        "luaVersion": "5.2"
+      }
+    },
+    {
+      "source": "do goto l1 goto l2 local x ::l1:: ::l2:: ::l3:: end",
+      "result": {
+        "type": "Chunk",
+        "body": [
+          {
+            "type": "DoStatement",
+            "body": [
+              {
+                "type": "GotoStatement",
+                "label": {
+                  "type": "Identifier",
+                  "name": "l1",
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 8
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 10
+                    }
+                  },
+                  "range": [
+                    8,
+                    10
+                  ]
+                },
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 3
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 10
+                  }
+                },
+                "range": [
+                  3,
+                  10
+                ]
+              },
+              {
+                "type": "GotoStatement",
+                "label": {
+                  "type": "Identifier",
+                  "name": "l2",
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 16
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 18
+                    }
+                  },
+                  "range": [
+                    16,
+                    18
+                  ]
+                },
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 18
+                  }
+                },
+                "range": [
+                  11,
+                  18
+                ]
+              },
+              {
+                "type": "LocalStatement",
+                "variables": [
+                  {
+                    "type": "Identifier",
+                    "name": "x",
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 25
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 26
+                      }
+                    },
+                    "range": [
+                      25,
+                      26
+                    ],
+                    "isLocal": true
+                  }
+                ],
+                "init": [],
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 19
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 26
+                  }
+                },
+                "range": [
+                  19,
+                  26
+                ]
+              },
+              {
+                "type": "LabelStatement",
+                "label": {
+                  "type": "Identifier",
+                  "name": "l1",
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 29
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 31
+                    }
+                  },
+                  "range": [
+                    29,
+                    31
+                  ],
+                  "isLocal": true
+                },
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 27
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 33
+                  }
+                },
+                "range": [
+                  27,
+                  33
+                ]
+              },
+              {
+                "type": "LabelStatement",
+                "label": {
+                  "type": "Identifier",
+                  "name": "l2",
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 36
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 38
+                    }
+                  },
+                  "range": [
+                    36,
+                    38
+                  ],
+                  "isLocal": true
+                },
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 34
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 40
+                  }
+                },
+                "range": [
+                  34,
+                  40
+                ]
+              },
+              {
+                "type": "LabelStatement",
+                "label": {
+                  "type": "Identifier",
+                  "name": "l3",
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 43
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 45
+                    }
+                  },
+                  "range": [
+                    43,
+                    45
+                  ],
+                  "isLocal": true
+                },
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 41
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 47
+                  }
+                },
+                "range": [
+                  41,
+                  47
+                ]
+              }
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "line": 1,
+                "column": 51
+              }
+            },
+            "range": [
+              0,
+              51
+            ]
+          }
+        ],
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 51
+          }
+        },
+        "range": [
+          0,
+          51
         ],
         "comments": [],
         "globals": []
@@ -664,7 +1213,7 @@
       }
     },
     {
-      "source": "goto foo",
+      "source": "goto foo ::foo::",
       "result": {
         "type": "Chunk",
         "body": [
@@ -702,6 +1251,42 @@
               0,
               8
             ]
+          },
+          {
+            "type": "LabelStatement",
+            "label": {
+              "type": "Identifier",
+              "name": "foo",
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 11
+                },
+                "end": {
+                  "line": 1,
+                  "column": 14
+                }
+              },
+              "range": [
+                11,
+                14
+              ],
+              "isLocal": true
+            },
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 9
+              },
+              "end": {
+                "line": 1,
+                "column": 16
+              }
+            },
+            "range": [
+              9,
+              16
+            ]
           }
         ],
         "loc": {
@@ -711,12 +1296,12 @@
           },
           "end": {
             "line": 1,
-            "column": 8
+            "column": 16
           }
         },
         "range": [
           0,
-          8
+          16
         ],
         "comments": [],
         "globals": []


### PR DESCRIPTION
closes #71

Also turns on `esversion: 6` for jshint. I think it's a non issue, even IE11 has partial support that includes the features I used for this PR (let, const, Map and arrow function).

> This project has hardly been very keen at keeping up with the Kardashians latest developments in the JavaScript world.

IMO the project should go trough a conversion stage to take advantage of ES6 features anyway.

I have also tested this PR against the [official lua test file for goto](https://github.com/lua/lua/blob/v5.3/testes/goto.lua).